### PR TITLE
Fix types and remove literal type on url type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,7 @@
 
 declare module 'usagiapi' {
     export class UsagiAPIClient {
-        url: 'https://usagiapi.danielagc.repl.co/api/'
+        url: string;
         async dance(): Promise<string>;
         async feed(): Promise<string>;
         async hug(): Promise<string>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,13 +2,14 @@
 declare module 'usagiapi' {
     export class UsagiAPIClient {
         url: string;
-        async dance(): Promise<string>;
-        async feed(): Promise<string>;
-        async hug(): Promise<string>;
-        async kiss(): Promise<string>;
-        async pat(): Promise<string>;
-        async poke(): Promise<string>;
-        async slap(): Promise<string>;
-        async tickle(): Promise<string>;
+        _request(routerName: string): Promise<string>;
+        dance(): Promise<string>;
+        feed(): Promise<string>;
+        hug(): Promise<string>;
+        kiss(): Promise<string>;
+        pat(): Promise<string>;
+        poke(): Promise<string>;
+        slap(): Promise<string>;
+        tickle(): Promise<string>;
     }
 }


### PR DESCRIPTION
the literal string type has limitations, in comparison for example. but the url cannot be of the literal type because it can be changed in the future.